### PR TITLE
Fix compilation error against libboost 1.67

### DIFF
--- a/host/lms6002d.cpp
+++ b/host/lms6002d.cpp
@@ -118,7 +118,7 @@ double lms6002d_dev::txrx_pll_tune(uint8_t reg, double ref_clock, double out_fre
     for (int i = 0; i < 64; i++) {
         // Update VCOCAP
         lms_write_bits(reg + 0x9, 0x3f, i);
-        usleep(50);
+        usleep(long(50));
 
         int comp = read_reg(reg + 0x0a);
         switch (comp >> 6) {
@@ -360,7 +360,7 @@ int lms6002d_dev::general_dc_calibration_loop(uint8_t dc_addr, uint8_t calibrati
         if (verbosity > 1) printf("cnt=%d\n", try_cnt_limit);
 
         // Wait for 6.4(1.6) us
-        usleep(6.4);
+        usleep(long(6.4));
 
         // Read DC_CLBR_DONE
         reg_val  = read_reg(calibration_reg_base+0x01);


### PR DESCRIPTION
That fixes the follwing compilation errors :

[ 56%] Building CXX object CMakeFiles/umtrx.dir/lms6002d_ctrl.cpp.o
[ 59%] Building CXX object CMakeFiles/umtrx.dir/tmp102_ctrl.cpp.o
/root/UHD-Fairwaves/host/lms6002d.cpp: In member function ‘int lms6002d_dev::general_dc_calibration_loop(uint8_t, uint8_t)’:
/root/UHD-Fairwaves/host/lms6002d.cpp:20:78: error: no matching function for call to ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>::subsecond_duration(double)’
 #define usleep(x) boost::this_thread::sleep(boost::posix_time::microseconds(x))
                                                                              ^
/root/UHD-Fairwaves/host/lms6002d.cpp:363:9: note: in expansion of macro ‘usleep’
         usleep(6.4);
         ^~~~~~
In file included from /usr/include/boost/date_time/posix_time/posix_time_config.hpp:16,
                 from /usr/include/boost/date_time/posix_time/posix_time_system.hpp:13,
                 from /usr/include/boost/date_time/posix_time/ptime.hpp:12,
                 from /usr/include/boost/date_time/posix_time/posix_time_types.hpp:12,
                 from /usr/include/boost/thread/thread_time.hpp:11,
                 from /usr/include/boost/thread/lock_types.hpp:18,
                 from /usr/include/boost/thread/pthread/thread_data.hpp:12,
                 from /usr/include/boost/thread/thread_only.hpp:17,
                 from /usr/include/boost/thread/thread.hpp:12,
                 from /usr/include/boost/thread.hpp:13,
                 from /root/UHD-Fairwaves/host/lms6002d.cpp:18:
/usr/include/boost/date_time/time_duration.hpp:285:14: note: candidate: ‘template<class T> boost::date_time::subsecond_duration<base_duration, frac_of_second>::subsecond_duration(const T&, typename boost::enable_if<boost::is_integral<T>, void>::type*)’
     explicit subsecond_duration(T const& ss,
              ^~~~~~~~~~~~~~~~~~
/usr/include/boost/date_time/time_duration.hpp:285:14: note:   template argument deduction/substitution failed:
/usr/include/boost/date_time/time_duration.hpp: In substitution of ‘template<class T> boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>::subsecond_duration(const T&, typename boost::enable_if<boost::is_integral<T>, void>::type*) [with T = double]’:
/root/UHD-Fairwaves/host/lms6002d.cpp:363:9:   required from here
/usr/include/boost/date_time/time_duration.hpp:285:14: error: no type named ‘type’ in ‘struct boost::enable_if<boost::is_integral<double>, void>’
In file included from /usr/include/boost/date_time/posix_time/posix_time_config.hpp:16,
                 from /usr/include/boost/date_time/posix_time/posix_time_system.hpp:13,
                 from /usr/include/boost/date_time/posix_time/ptime.hpp:12,
                 from /usr/include/boost/date_time/posix_time/posix_time_types.hpp:12,
                 from /usr/include/boost/thread/thread_time.hpp:11,
                 from /usr/include/boost/thread/lock_types.hpp:18,
                 from /usr/include/boost/thread/pthread/thread_data.hpp:12,
                 from /usr/include/boost/thread/thread_only.hpp:17,
                 from /usr/include/boost/thread/thread.hpp:12,
                 from /usr/include/boost/thread.hpp:13,
                 from /root/UHD-Fairwaves/host/lms6002d.cpp:18:
/usr/include/boost/date_time/time_duration.hpp:270:30: note: candidate: ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>::subsecond_duration(const boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>&)’
   class BOOST_SYMBOL_VISIBLE subsecond_duration : public base_duration
                              ^~~~~~~~~~~~~~~~~~
/usr/include/boost/date_time/time_duration.hpp:270:30: note:   no known conversion for argument 1 from ‘double’ to ‘const boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>&’
/usr/include/boost/date_time/time_duration.hpp:270:30: note: candidate: ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>::subsecond_duration(boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>&&)’
/usr/include/boost/date_time/time_duration.hpp:270:30: note:   no known conversion for argument 1 from ‘double’ to ‘boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000000>&&’
[ 62%] Building CXX object CMakeFiles/umtrx.dir/ads1015_ctrl.cpp.o
make[2]: *** [CMakeFiles/umtrx.dir/build.make:141: CMakeFiles/umtrx.dir/lms6002d.cpp.o] Error 1
make[2]: *** Attente des tâches non terminées....
make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/umtrx.dir/all] Error 2
make: *** [Makefile:152: all] Error 2`
