### PR TITLE
UHD 4 port

### DIFF
--- a/host/cores/apply_corrections.cpp
+++ b/host/cores/apply_corrections.cpp
@@ -21,6 +21,7 @@
 #include "umtrx_log_adapter.hpp"
 #include <uhd/utils/csv.hpp>
 #include <uhd/types/dict.hpp>
+#include <uhd/version.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/thread/mutex.hpp>
@@ -104,7 +105,13 @@ static void apply_fe_corrections(
     const uhd::usrp::dboard_eeprom_t db_eeprom = sub_tree->access<uhd::usrp::dboard_eeprom_t>(db_path).get();
 
     //make the calibration file path
+    //UHD4 deprecated get_app_path and uses designated calibration path (introduced earlier)
+    //Don't break existing UHD3 installs, so use cal path only on UHD4
+#if UHD_VERSION >= 4000000
     const fs::path cal_data_path = fs::path(uhd::get_cal_data_path()) / (file_prefix + db_eeprom.serial + ".csv");
+#else
+    const fs::path cal_data_path = fs::path(uhd::get_app_path()) / ".uhd" / "cal" / (file_prefix + db_eeprom.serial + ".csv");
+#endif
     UHD_MSG(status) << "Looking for FE correction at: " << cal_data_path.c_str() << "...  ";
     if (not fs::exists(cal_data_path)) {
         UHD_MSG(status) << "Not found" << std::endl;

--- a/host/cores/apply_corrections.cpp
+++ b/host/cores/apply_corrections.cpp
@@ -104,7 +104,7 @@ static void apply_fe_corrections(
     const uhd::usrp::dboard_eeprom_t db_eeprom = sub_tree->access<uhd::usrp::dboard_eeprom_t>(db_path).get();
 
     //make the calibration file path
-    const fs::path cal_data_path = fs::path(uhd::get_app_path()) / ".uhd" / "cal" / (file_prefix + db_eeprom.serial + ".csv");
+    const fs::path cal_data_path = fs::path(uhd::get_cal_data_path()) / (file_prefix + db_eeprom.serial + ".csv");
     UHD_MSG(status) << "Looking for FE correction at: " << cal_data_path.c_str() << "...  ";
     if (not fs::exists(cal_data_path)) {
         UHD_MSG(status) << "Not found" << std::endl;

--- a/host/cores/super_recv_packet_handler.hpp
+++ b/host/cores/super_recv_packet_handler.hpp
@@ -32,7 +32,7 @@
 #include <boost/foreach.hpp>
 #include <boost/function.hpp>
 #include <boost/format.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/thread/barrier.hpp>
 #include <iostream>

--- a/host/umtrx_common.hpp
+++ b/host/umtrx_common.hpp
@@ -1,0 +1,12 @@
+#ifndef INCLUDED_UMTRX_COMMON_HPP
+#define INCLUDED_UMTRX_COMMON_HPP
+
+#include <uhd/version.hpp>
+
+#if UHD_VERSION >= 4000000
+#define UMTRX_UHD_PTR_NAMESPACE std
+#else
+#define UMTRX_UHD_PTR_NAMESPACE boost
+#endif
+
+#endif /* INCLUDED_UMTRX_COMMON_HPP */

--- a/host/umtrx_fifo_ctrl.hpp
+++ b/host/umtrx_fifo_ctrl.hpp
@@ -34,7 +34,7 @@
 class umtrx_fifo_ctrl : public uhd::wb_iface, public uhd::spi_iface
 {
 public:
-    typedef boost::shared_ptr<umtrx_fifo_ctrl> sptr;
+    typedef std::shared_ptr<umtrx_fifo_ctrl> sptr;
 
     //! Make a new FIFO control object
     static sptr make(uhd::transport::zero_copy_if::sptr xport, const boost::uint32_t sid, const size_t window_size);

--- a/host/umtrx_fifo_ctrl.hpp
+++ b/host/umtrx_fifo_ctrl.hpp
@@ -27,6 +27,8 @@
 #include <uhd/types/wb_iface.hpp>
 #include <string>
 
+#include "umtrx_common.hpp"
+
 /*!
  * The umtrx FIFO control class:
  * Provide high-speed peek/poke interface.
@@ -34,7 +36,7 @@
 class umtrx_fifo_ctrl : public uhd::wb_iface, public uhd::spi_iface
 {
 public:
-    typedef std::shared_ptr<umtrx_fifo_ctrl> sptr;
+    typedef UMTRX_UHD_PTR_NAMESPACE::shared_ptr<umtrx_fifo_ctrl> sptr;
 
     //! Make a new FIFO control object
     static sptr make(uhd::transport::zero_copy_if::sptr xport, const boost::uint32_t sid, const size_t window_size);

--- a/host/umtrx_find.cpp
+++ b/host/umtrx_find.cpp
@@ -24,6 +24,7 @@
 #include <uhd/transport/if_addrs.hpp>
 #include <uhd/transport/udp_simple.hpp>
 #include <boost/asio.hpp>
+#include <boost/foreach.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/umtrx_iface.cpp
+++ b/host/umtrx_iface.cpp
@@ -30,7 +30,7 @@
 #include <boost/asio.hpp> //used for htonl and ntohl
 #include <boost/assign/list_of.hpp>
 #include <boost/format.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/functional/hash.hpp>
 #include <algorithm>

--- a/host/umtrx_iface.cpp
+++ b/host/umtrx_iface.cpp
@@ -60,7 +60,6 @@ static const boost::uint32_t MIN_PROTO_COMPAT_I2C = 7;
 // The register compat number must reflect the protocol compatibility
 // and the compatibility of the register mapping (more likely to change).
 static const boost::uint32_t MIN_PROTO_COMPAT_REG = 10;
-static const boost::uint32_t MIN_PROTO_COMPAT_UART = 7;
 
 class umtrx_iface_impl : public umtrx_iface{
 public:

--- a/host/umtrx_iface.hpp
+++ b/host/umtrx_iface.hpp
@@ -27,6 +27,8 @@
 #include <boost/function.hpp>
 #include <string>
 
+#include "umtrx_common.hpp"
+
 /*!
  * The umtrx interface class:
  * Provides a set of functions to implementation layer.
@@ -34,7 +36,7 @@
  */
 class umtrx_iface : public uhd::wb_iface, public uhd::spi_iface, public uhd::i2c_iface{
 public:
-    typedef std::shared_ptr<umtrx_iface> sptr;
+    typedef UMTRX_UHD_PTR_NAMESPACE::shared_ptr<umtrx_iface> sptr;
     /*!
      * Make a new umtrx interface with the control transport.
      * \param ctrl_transport the udp transport object

--- a/host/umtrx_iface.hpp
+++ b/host/umtrx_iface.hpp
@@ -34,7 +34,7 @@
  */
 class umtrx_iface : public uhd::wb_iface, public uhd::spi_iface, public uhd::i2c_iface{
 public:
-    typedef boost::shared_ptr<umtrx_iface> sptr;
+    typedef std::shared_ptr<umtrx_iface> sptr;
     /*!
      * Make a new umtrx interface with the control transport.
      * \param ctrl_transport the udp transport object

--- a/host/umtrx_impl.cpp
+++ b/host/umtrx_impl.cpp
@@ -25,6 +25,7 @@
 #include <boost/thread.hpp> //sleep
 #include <boost/assign/list_of.hpp>
 #include <boost/utility.hpp>
+#include <boost/foreach.hpp>
 
 static int verbosity = 0;
 

--- a/host/umtrx_impl.hpp
+++ b/host/umtrx_impl.hpp
@@ -40,7 +40,6 @@
 #include <uhd/types/dict.hpp>
 #include <uhd/types/stream_cmd.hpp>
 #include <uhd/types/sensors.hpp>
-#include <uhd/types/clock_config.hpp>
 #include <uhd/usrp/dboard_eeprom.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>

--- a/host/umtrx_impl.hpp
+++ b/host/umtrx_impl.hpp
@@ -236,8 +236,8 @@ private:
     void client_query_handle1(const boost::property_tree::ptree &request, boost::property_tree::ptree &response);
 
     //streaming
-    std::vector<boost::weak_ptr<uhd::rx_streamer> > _rx_streamers;
-    std::vector<boost::weak_ptr<uhd::tx_streamer> > _tx_streamers;
+    std::vector<std::weak_ptr<uhd::rx_streamer> > _rx_streamers;
+    std::vector<std::weak_ptr<uhd::tx_streamer> > _tx_streamers;
     boost::mutex _setupMutex;
 };
 

--- a/host/umtrx_impl.hpp
+++ b/host/umtrx_impl.hpp
@@ -20,6 +20,7 @@
 #define INCLUDED_UMTRX_IMPL_HPP
 
 #include "usrp2/fw_common.h"
+#include "umtrx_common.hpp"
 #include "umtrx_iface.hpp"
 #include "umtrx_fifo_ctrl.hpp"
 #include "lms6002d_ctrl.hpp"
@@ -236,8 +237,8 @@ private:
     void client_query_handle1(const boost::property_tree::ptree &request, boost::property_tree::ptree &response);
 
     //streaming
-    std::vector<std::weak_ptr<uhd::rx_streamer> > _rx_streamers;
-    std::vector<std::weak_ptr<uhd::tx_streamer> > _tx_streamers;
+    std::vector<UMTRX_UHD_PTR_NAMESPACE::weak_ptr<uhd::rx_streamer> > _rx_streamers;
+    std::vector<UMTRX_UHD_PTR_NAMESPACE::weak_ptr<uhd::tx_streamer> > _tx_streamers;
     boost::mutex _setupMutex;
 };
 

--- a/host/umtrx_io_impl.cpp
+++ b/host/umtrx_io_impl.cpp
@@ -105,8 +105,8 @@ void umtrx_impl::update_rates(void)
 
 void umtrx_impl::update_rx_samp_rate(const size_t dsp, const double rate)
 {
-    std::shared_ptr<sph::recv_packet_streamer> my_streamer =
-        std::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[dsp].lock());
+    UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::recv_packet_streamer> my_streamer =
+        UMTRX_UHD_PTR_NAMESPACE::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[dsp].lock());
     if (not my_streamer) return;
 
     my_streamer->set_samp_rate(rate);
@@ -116,8 +116,8 @@ void umtrx_impl::update_rx_samp_rate(const size_t dsp, const double rate)
 
 void umtrx_impl::update_tx_samp_rate(const size_t dsp, const double rate)
 {
-    std::shared_ptr<sph::send_packet_streamer> my_streamer =
-        std::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[dsp].lock());
+    UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::send_packet_streamer> my_streamer =
+        UMTRX_UHD_PTR_NAMESPACE::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[dsp].lock());
     if (not my_streamer) return;
 
     my_streamer->set_samp_rate(rate);
@@ -130,15 +130,15 @@ void umtrx_impl::update_tick_rate(const double rate)
     //update the tick rate on all existing streamers -> thread safe
     for (size_t i = 0; i < _rx_streamers.size(); i++)
     {
-        std::shared_ptr<sph::recv_packet_streamer> my_streamer =
-            std::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[i].lock());
+        UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::recv_packet_streamer> my_streamer =
+            UMTRX_UHD_PTR_NAMESPACE::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[i].lock());
         if (not my_streamer) continue;
         my_streamer->set_tick_rate(rate);
     }
     for (size_t i = 0; i < _tx_streamers.size(); i++)
     {
-        std::shared_ptr<sph::send_packet_streamer> my_streamer =
-            std::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[i].lock());
+        UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::send_packet_streamer> my_streamer =
+            UMTRX_UHD_PTR_NAMESPACE::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[i].lock());
         if (not my_streamer) continue;
         my_streamer->set_tick_rate(rate);
     }
@@ -228,7 +228,7 @@ uhd::rx_streamer::sptr umtrx_impl::get_rx_stream(const uhd::stream_args_t &args_
     const size_t spp = unsigned(args.args.cast<double>("spp", bpp/bpi));
 
     //make the new streamer given the samples per packet
-    std::shared_ptr<sph::recv_packet_streamer> my_streamer = std::make_shared<sph::recv_packet_streamer>(spp);
+    UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::recv_packet_streamer> my_streamer = UMTRX_UHD_PTR_NAMESPACE::make_shared<sph::recv_packet_streamer>(spp);
 
     //init some streamer stuff
     my_streamer->resize(args.channels.size());
@@ -454,7 +454,7 @@ uhd::tx_streamer::sptr umtrx_impl::get_tx_stream(const uhd::stream_args_t &args_
     const size_t spp = bpp/convert::get_bytes_per_item(args.otw_format);
 
     //make the new streamer given the samples per packet
-    std::shared_ptr<sph::send_packet_streamer> my_streamer = std::make_shared<sph::send_packet_streamer>(spp);
+    UMTRX_UHD_PTR_NAMESPACE::shared_ptr<sph::send_packet_streamer> my_streamer = UMTRX_UHD_PTR_NAMESPACE::make_shared<sph::send_packet_streamer>(spp);
 
     //init some streamer stuff
     my_streamer->resize(args.channels.size());

--- a/host/umtrx_io_impl.cpp
+++ b/host/umtrx_io_impl.cpp
@@ -249,10 +249,10 @@ uhd::rx_streamer::sptr umtrx_impl::get_rx_stream(const uhd::stream_args_t &args_
         _rx_dsps[dsp]->set_nsamps_per_packet(spp); //seems to be a good place to set this
         _rx_dsps[dsp]->setup(args);
         my_streamer->set_xport_chan_get_buff(chan_i, boost::bind(
-            &zero_copy_if::get_recv_buff, xports[chan_i], _1
+            &zero_copy_if::get_recv_buff, xports[chan_i], boost::placeholders::_1
         ), true /*flush*/);
         my_streamer->set_issue_stream_cmd(chan_i, boost::bind(
-            &rx_dsp_core_200::issue_stream_command, _rx_dsps[dsp], _1));
+            &rx_dsp_core_200::issue_stream_command, _rx_dsps[dsp], boost::placeholders::_1));
         _rx_streamers[dsp] = my_streamer; //store weak pointer
     }
 
@@ -471,7 +471,7 @@ uhd::tx_streamer::sptr umtrx_impl::get_tx_stream(const uhd::stream_args_t &args_
     //shared async queue for all channels in streamer
     boost::shared_ptr<async_md_type> async_md(new async_md_type(1000/*messages deep*/));
     if (not _old_async_queue) _old_async_queue.reset(new async_md_type(1000/*messages deep*/));
-    my_streamer->set_async_receiver(boost::bind(&async_md_type::pop_with_timed_wait, async_md, _1, _2));
+    my_streamer->set_async_receiver(boost::bind(&async_md_type::pop_with_timed_wait, async_md, boost::placeholders::_1, boost::placeholders::_2));
 
     //bind callbacks for the handler
     for (size_t chan_i = 0; chan_i < args.channels.size(); chan_i++)
@@ -506,7 +506,7 @@ uhd::tx_streamer::sptr umtrx_impl::get_tx_stream(const uhd::stream_args_t &args_
 
         //buffer get method handles flow control and hold task reference count
         my_streamer->set_xport_chan_get_buff(chan_i, boost::bind(
-            &get_send_buff, task, fc_mon, xports[chan_i], _1
+            &get_send_buff, task, fc_mon, xports[chan_i], boost::placeholders::_1
         ));
 
         _tx_streamers[dsp] = my_streamer; //store weak pointer

--- a/host/umtrx_io_impl.cpp
+++ b/host/umtrx_io_impl.cpp
@@ -39,7 +39,6 @@ static const size_t DEFAULT_NUM_FRAMES = 32;
 using namespace uhd;
 using namespace uhd::usrp;
 using namespace uhd::transport;
-namespace asio = boost::asio;
 namespace pt = boost::posix_time;
 
 /***********************************************************************
@@ -110,8 +109,8 @@ void umtrx_impl::update_rates(void)
 
 void umtrx_impl::update_rx_samp_rate(const size_t dsp, const double rate)
 {
-    boost::shared_ptr<sph::recv_packet_streamer> my_streamer =
-        boost::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[dsp].lock());
+    std::shared_ptr<sph::recv_packet_streamer> my_streamer =
+        std::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[dsp].lock());
     if (not my_streamer) return;
 
     my_streamer->set_samp_rate(rate);
@@ -121,8 +120,8 @@ void umtrx_impl::update_rx_samp_rate(const size_t dsp, const double rate)
 
 void umtrx_impl::update_tx_samp_rate(const size_t dsp, const double rate)
 {
-    boost::shared_ptr<sph::send_packet_streamer> my_streamer =
-        boost::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[dsp].lock());
+    std::shared_ptr<sph::send_packet_streamer> my_streamer =
+        std::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[dsp].lock());
     if (not my_streamer) return;
 
     my_streamer->set_samp_rate(rate);
@@ -135,15 +134,15 @@ void umtrx_impl::update_tick_rate(const double rate)
     //update the tick rate on all existing streamers -> thread safe
     for (size_t i = 0; i < _rx_streamers.size(); i++)
     {
-        boost::shared_ptr<sph::recv_packet_streamer> my_streamer =
-            boost::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[i].lock());
+        std::shared_ptr<sph::recv_packet_streamer> my_streamer =
+            std::dynamic_pointer_cast<sph::recv_packet_streamer>(_rx_streamers[i].lock());
         if (not my_streamer) continue;
         my_streamer->set_tick_rate(rate);
     }
     for (size_t i = 0; i < _tx_streamers.size(); i++)
     {
-        boost::shared_ptr<sph::send_packet_streamer> my_streamer =
-            boost::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[i].lock());
+        std::shared_ptr<sph::send_packet_streamer> my_streamer =
+            std::dynamic_pointer_cast<sph::send_packet_streamer>(_tx_streamers[i].lock());
         if (not my_streamer) continue;
         my_streamer->set_tick_rate(rate);
     }
@@ -233,7 +232,7 @@ uhd::rx_streamer::sptr umtrx_impl::get_rx_stream(const uhd::stream_args_t &args_
     const size_t spp = unsigned(args.args.cast<double>("spp", bpp/bpi));
 
     //make the new streamer given the samples per packet
-    boost::shared_ptr<sph::recv_packet_streamer> my_streamer = boost::make_shared<sph::recv_packet_streamer>(spp);
+    std::shared_ptr<sph::recv_packet_streamer> my_streamer = std::make_shared<sph::recv_packet_streamer>(spp);
 
     //init some streamer stuff
     my_streamer->resize(args.channels.size());
@@ -459,7 +458,7 @@ uhd::tx_streamer::sptr umtrx_impl::get_tx_stream(const uhd::stream_args_t &args_
     const size_t spp = bpp/convert::get_bytes_per_item(args.otw_format);
 
     //make the new streamer given the samples per packet
-    boost::shared_ptr<sph::send_packet_streamer> my_streamer = boost::make_shared<sph::send_packet_streamer>(spp);
+    std::shared_ptr<sph::send_packet_streamer> my_streamer = std::make_shared<sph::send_packet_streamer>(spp);
 
     //init some streamer stuff
     my_streamer->resize(args.channels.size());

--- a/host/umtrx_io_impl.cpp
+++ b/host/umtrx_io_impl.cpp
@@ -48,10 +48,6 @@ static UHD_INLINE pt::time_duration to_time_dur(double timeout){
     return pt::microseconds(long(timeout*1e6));
 }
 
-static UHD_INLINE double from_time_dur(const pt::time_duration &time_dur){
-    return 1e-6*time_dur.total_microseconds();
-}
-
 /***********************************************************************
  * constants
  **********************************************************************/

--- a/host/umtrx_monitor.cpp
+++ b/host/umtrx_monitor.cpp
@@ -20,6 +20,7 @@
 #include <uhd/types/sensors.hpp>
 #include <uhd/types/ranges.hpp>
 #include <boost/asio.hpp>
+#include <boost/foreach.hpp>
 
 using namespace uhd;
 using namespace uhd::usrp;

--- a/host/utils/usrp_cal_utils.hpp
+++ b/host/utils/usrp_cal_utils.hpp
@@ -138,9 +138,7 @@ static void store_results(
     std::string serial = get_serial(usrp, rx_tx);
 
     //make the calibration file path
-    fs::path cal_data_path = fs::path(uhd::get_app_path()) / ".uhd";
-    fs::create_directory(cal_data_path);
-    cal_data_path = cal_data_path / "cal";
+    fs::path cal_data_path = fs::path(uhd::get_cal_data_path());
     fs::create_directory(cal_data_path);
     cal_data_path = cal_data_path / str(boost::format("%s_%s_cal_v0.2_%s.csv") % rx_tx % what % serial);
     if (fs::exists(cal_data_path)){

--- a/host/utils/usrp_cal_utils.hpp
+++ b/host/utils/usrp_cal_utils.hpp
@@ -26,6 +26,7 @@
 #include <uhd/property_tree.hpp>
 #include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/usrp/dboard_eeprom.hpp>
+#include <uhd/version.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread/thread.hpp>
@@ -138,7 +139,15 @@ static void store_results(
     std::string serial = get_serial(usrp, rx_tx);
 
     //make the calibration file path
+    //UHD4 deprecated get_app_path and uses designated calibration path (introduced earlier)
+    //Don't break existing UHD3 installs, so use cal path only on UHD4
+#if UHD_VERSION >= 4000000
     fs::path cal_data_path = fs::path(uhd::get_cal_data_path());
+#else
+    fs::path cal_data_path = fs::path(uhd::get_app_path()) / ".uhd";
+    fs::create_directory(cal_data_path);
+    cal_data_path = cal_data_path / "cal";
+#endif
     fs::create_directory(cal_data_path);
     cal_data_path = cal_data_path / str(boost::format("%s_%s_cal_v0.2_%s.csv") % rx_tx % what % serial);
     if (fs::exists(cal_data_path)){


### PR DESCRIPTION
Fix incompatibilities from UHD version 4 to make UHD-Fairwaves build with UHD 4.

~Might break compatibility to libuhd 3.~ ~That was obvious 58b4d869d48cf7b44ba4cb90cbf3f0e7f6f27100 broke libuhd 3. If the upstream project is alive and willing to accept this, I'm going to make build process changes to detect libuhd 3 and change pointer types between `std` and Boost.~ Now fixed.

Build-tested on Fedora's libuhd UHD_4.4.0.0 with GCC 13 and Clang 16 and UHD 4.5 from repos and 3.15 from git on Arch with GCC 13.

~`uhd_find_devices` detection is broken~ was doing in a wrong prefix. Works like a charm now. Testing is not comprehensive, but looks ok. Radio RX, `uhd_find_devices`, `uhd_usrp_probe`, `latency_test`, `usrp_list_sensors` all work.

Thanks for UmTRX, it's an amazing tool!